### PR TITLE
[DM-3921] S3 Notifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'after_do', '0.3.1'
 gem 'json', '~> 1.8.3'
 gem 'lsst-git-lfs-s3', '0.2.5'
 gem 'octokit', '4.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
+    after_do (0.3.1)
     aws-sdk (2.1.30)
       aws-sdk-resources (= 2.1.30)
     aws-sdk-core (2.1.30)
@@ -49,6 +50,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  after_do (= 0.3.1)
   highline (= 1.7.3)
   json (~> 1.8.3)
   lsst-git-lfs-s3 (= 0.2.5)
@@ -56,6 +58,3 @@ DEPENDENCIES
   passenger (= 5.0.20)
   redis (= 3.2.1)
   scrypt (= 2.0.2)
-
-BUNDLED WITH
-   1.10.6

--- a/git-lfs-s3-server.rb
+++ b/git-lfs-s3-server.rb
@@ -84,7 +84,9 @@ def get_password_hash(username)
   # Use the request username to avoid using the github API unnecessarily.
   if @redis.connected?
     cached_hash = @redis.get(username)
-    SCrypt::Password.new(cached_hash)
+    if cached_hash
+      SCrypt::Password.new(cached_hash)
+    end
   end
 end
 

--- a/git-lfs-s3-server.rb
+++ b/git-lfs-s3-server.rb
@@ -71,8 +71,8 @@ def org_member?(client)
     end
   rescue Octokit::OneTimePasswordRequired => e
     GitLfsS3::Application.settings.logger.warn\
-      'Octokit::OneTimePasswordRequired exception raised for username #{username}. '\
-      'Please use a personal access token.'
+      "Octokit::OneTimePasswordRequired exception raised for username #{username}. "\
+      "Please use a personal access token."
     return false
   rescue Octokit::Unauthorized
     return false
@@ -157,10 +157,10 @@ GitLfsS3::Application.after :call do |env, app|
       if not @redis.get('backup=>' + oid_s3_name)
         @redis.publish 'backup', oid_s3_name
         # Log publish message.
-        GitLfsS3::Application.settings.logger.debug 'Publish message to backup S3 object #{oid_s3_name}.'
+        GitLfsS3::Application.settings.logger.debug "Publish message to backup S3 object #{oid_s3_name}."
       end
     else
-      GitLfsS3::Application.settings.logger.warn 'Unable to backup oid = #{oid}'
+      GitLfsS3::Application.settings.logger.warn "Unable to backup oid = #{oid}"
     end
   end
 end


### PR DESCRIPTION
S3 Notifications
============

Notify an external backup service when there are new POSTs to the '/verify' path of the git-lfs web server.

This is one of two pull requests to help meet the git-lfs project requirement to externally backup git-lfs blobs. The other coming from the [s3 to s3 backup service](https://github.com/jmatt/s3s3).

### Summary ###

After an HTTP POST to `/verify` publish a message to redis' `backup` channel with the S3 key/object name.

### Implementation details###

To facilitate this the [after_do](https://github.com/PragTob/after_do) ruby library is used to keep notification code external to the lsst-git-lfs-s3 library. This is complex because Sinatra uses a single base `:call` method for all routes.

[Redis pubsub](http://redis.io/topics/pubsub) is used to publish to the s3 key/object name to the `backup` channel. Redis is used instead of SNS to avoid any unnecessary dependencies on AWS services.

### Concerns ###

1. The `git-lfs-s3-server.rb` file is arguably complex enough to be split between more than one file.
2. I don't have a complete understanding of Sinatra internals and though no problems have been found there may still be issues.
3. I have not tested redis over an extremely long time period. I don't know know what to expect from redis publish / subscribe after hundreds of days of run-time.