### PR TITLE
[DM-9673] Reconfigure git-lfs nginx port 80.

### DIFF
--- a/extras/git-lfs-s3-server.conf
+++ b/extras/git-lfs-s3-server.conf
@@ -1,11 +1,12 @@
 server {
-    listen 80;
-    server_name git-lfs.lsst.codes;
-    return 301 https://git-lfs.lsst.codes$request_uri;
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    return 301 https://$host$request_uri;
 }
 
 server {
-    listen 443;
+    listen 443 ssl http2 default_server;
     server_name git-lfs.lsst.codes;
 
     ssl on;
@@ -29,14 +30,11 @@ server {
     resolver 8.8.4.4 8.8.8.8 valid=600s;
     resolver_timeout 10s;
 
-    spdy_keepalive_timeout 300;
-    spdy_headers_comp 9;
-
     add_header Strict-Transport-Security max-age=63072000;
     add_header X-Frame-Options DENY;
     add_header X-Content-Type-Options nosniff;
 
-    root /opt/dev/git-lfs-s3-server/public;
+    root /opt/lsst/git-lfs-s3-server/public;
 
     passenger_enabled on;
 }


### PR DESCRIPTION
  * Git-lfs port 80 was defaulting to http2.
  * Redirect requests other than git-lfs.lsst.codes.