### PR TITLE
rename redis env vars to not be k8s specific

### DIFF
--- a/git-lfs-s3-server.rb
+++ b/git-lfs-s3-server.rb
@@ -31,8 +31,8 @@ GITHUB_ORG = ENV['LFS_GITHUB_ORG'] || 'lsst'
 args = {}
 
 {
-  'REDIS_SERVICE_HOST' => :host,
-  'REDIS_SERVICE_PORT' => :port,
+  'LFS_REDIS_HOST' => :host,
+  'LFS_REDIS_PORT' => :port,
 }.each do |k, v|
   ENV.key?(k) && args[v] = ENV[k]
 end


### PR DESCRIPTION
As these will change when the k8s service name changes.

env var renames:

- REDIS_SERVICE_HOST -> LFS_REDIS_HOST
- REDIS_SERVICE_PORT -> LFS_REDIS_PORT